### PR TITLE
Add typescript-eslint rules for better promise practices

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/await-thenable': 'error',
     '@typescript-eslint/require-await': 'error',
+    '@typescript-eslint/no-unsafe-return': 'error',
     'import/prefer-default-export': 'off',
     'import/no-default-export': 'error',
     'max-len': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,8 @@ module.exports = {
   },
   plugins: ['@typescript-eslint'],
   rules: {
+    '@typescript-eslint/await-thenable': 'error',
+    '@typescript-eslint/require-await': 'error',
     'import/prefer-default-export': 'off',
     'import/no-default-export': 'error',
     'max-len': [

--- a/src/klickerKnight.ts
+++ b/src/klickerKnight.ts
@@ -5,5 +5,7 @@ export class KlickerKnight extends Command {
     this.log(
       'You helplessly stare into the void as you try to gain your bearings. Your foot catches on what you believe to be a loose flagstone. You fall and break your neck. You are dead.'
     );
+
+    return Promise.resolve();
   }
 }


### PR DESCRIPTION
## Description

- [await-thenable](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/await-thenable.md): prevent awaiting non-thenables
- [require-await](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/require-await.md): Same as eslint. No async without an await or a returned promise.
- [no-unsafe-return](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unsafe-return.md): Prevents casting `any` to some other type