### PR TITLE
Add documentation with mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ npm run dev
   "eslint.format.enable": true,
 }
 ```
+
+### Recommended VSCode Extensions
+
+- [GitHub Markdown Preview](https://marketplace.visualstudio.com/items?itemName=bierner.github-markdown-preview)
+- [Markdown Preview Mermaid Support](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid)
+- [Mermaid Markdown Syntax Highlighting](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting)
+
+### Documentation
+
+Docs are located in [./docs/](./docs/). A good place to start is [./docs/client.md](./docs/client.md).

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,0 +1,28 @@
+# Client
+
+The client is the entry point of the application along with some of the top level logic that runs on each command.
+
+See the [Data Abstraction](./dataAbstraction.md), [RoomHandlerUtil](./roomHandlerUtil.md) and [RoomHandler](./roomHandler.md)
+diagrams for more details on their behavior.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor P as Player
+  participant C as Client
+  participant RH as RoomHandler
+
+  P ->> C: klicker-knight [<command = 'default'>] [...<subcommands>]
+  C ->> C: gameState: GameState = <br>gameStateUtil.load()
+  C ->> C: handler: RoomHandler = roomHandlerUtil.lookup(gameState)
+
+  C ->> RH: handler.run(gameState, command, ...subcommands)
+  RH ->> C: newGameState: GameState
+
+  alt game state changed
+    C ->> C: gameStateUtil.save(newGameState: GameState)
+  end
+
+  C ->> C: output: string = <br> gameState.getDescriptionAndCommands()
+  C ->> P: current command description, <br> current room description, <br> and available commands
+```

--- a/docs/dataAbstraction.md
+++ b/docs/dataAbstraction.md
@@ -1,0 +1,47 @@
+# Data Abstraction
+
+The GameStateUtil abstracts the behavior of the DatabaseUtil and the underlying JSON file where the game state is stored.
+
+See the [client](./client.md) diagram for more information on how `gameStateUtil` is invoked.
+
+## Save
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant A as Anything
+  participant G as GameStateUtil
+  participant D as DatabaseUtil
+  participant F as File
+
+  A ->> G: gameStateUtil.save(newGameState: GameState)
+  G ->> D: databaseUtil.save(gameState: object)
+  D ->> D: serialize gameState
+  D ->> F: write serialized gameState
+```
+
+## Load
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant A as Anything
+  participant G as GameStateUtil
+  participant D as DatabaseUtil
+  participant F as File
+
+  A ->> G: gameStateUtil.load()
+  G ->> D: databaseUtil.load()
+  D ->> F: read file
+  F ->> D: serializedData: string
+  D ->> D: parse serializedData
+  D ->> G: data: unknown
+  G ->> G: validate data <br> is GameState
+
+  alt data is not valid
+    G ->> G: init() <br> gameState: GameState
+    G ->> D: save -> see "Save" diagram
+  end
+
+  G ->> A: gameState: GameState
+```

--- a/docs/room.md
+++ b/docs/room.md
@@ -1,0 +1,9 @@
+# Room
+
+A room is an abstract concept that the player exists in and interacts with. Rooms are modeled by [RoomHandler](./roomHandler.md)s
+
+The following applies to all rooms:
+
+- A room has one entrance (door)
+- A room has one or more exits (doors)
+- All entrances are locked and cannot be exits

--- a/docs/roomHandler.md
+++ b/docs/roomHandler.md
@@ -1,0 +1,40 @@
+# RoomHandler
+
+A RoomHandler models the different states and state transitions of a [room](./room.md).
+RoomHandler is an abstract class, so specific room handlers are documented in [./roomHandlers/](./roomHandlers/).
+
+The player is always in a known room, and in the context of that room,
+the player is always in a known room state.
+When a player triggers an action via a command, the game can report the
+description of the action and the description of the resulting room state.
+The player invokes the following to trigger a state transition:
+
+```bash
+klicker-knight <command> [...<subcommands>]
+```
+
+The default command is `default`.
+
+See the [client](./client) diagram for more information on how a RoomHandler is invoked with a command and subcommands.
+
+## States
+
+- **AtEntrance**: The initial state of a room. Specific room handler docs should specify what the player sees at the entrance.
+
+## Transitions
+
+- **default**: Specific room handlers should specify what the player sees at the entrance
+- **leave \<doorIdentifier\>**: The player wants to leave the room via the specified door.
+Rooms with one door may have a default `doorIdentifier`.
+The `doorIdentifier` can be  used to perform special behavior before leaving the room.
+Leaving is implemented by setting or randomizing the room id of the current game state.
+
+## State Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> AtEntrance
+
+  AtEntrance --> AtEntrance: default
+  AtEntrance --> [*]: leave {doorIdentifier}
+```

--- a/docs/roomHandlerUtil.md
+++ b/docs/roomHandlerUtil.md
@@ -1,0 +1,24 @@
+# RoomHandlerUtil
+
+The roomHandlerUtil abstracts looking up the [RoomHandler](./roomHandler.md)
+for a specific [Room](./room.md) based on a `roomId`.
+`roomId` is of type `RoomId` which is an enum or string union.
+
+See the [client](./client.md) diagram to see how the roomHandlerUtil is invoked.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant A as Anything
+  participant RHU as RoomHandlerUtil
+  participant RHS as RoomHandler Subclass
+  participant RHC as RoomHandler<T extends RoomId> <br> Class
+
+  A ->> RHU: roomHandlerUtil.lookup(roomId: RoomId)
+  RHU ->> RHU: Find corresponding <br> RoomHandler subclass <br> (RoomHandler<roomId>)
+  RHU ->> RHS: new RoomHandler<roomId>();
+  RHS ->> RHC: super()
+  RHS ->> RHU: room: RoomHandler<roomId>
+  note over A,RHU: Note that the below type <br> is RoomId and not roomId <br> because the specific type <br> shouldn't matter
+  RHU ->> A: room: RoomHandler<RoomId>
+```

--- a/docs/roomHandlers/decisionRoom.md
+++ b/docs/roomHandlers/decisionRoom.md
@@ -1,0 +1,27 @@
+# Decision Room
+
+A room with two doors. Taking the door on the left moves the player to the next random room.
+Taking the door on the right takes the player back to the same room.
+
+## States
+
+- **AtEntrance**: The player is in a room two doors. The game should indicate that the player will take the door on the left
+- **AttemptingToLeave**: The player is walking down a long hallway and is about to round a corner.
+
+## Transitions
+
+- **leave <'left' | 'right'>**: The player leaves the room via the `doorIdentifier` door
+- **continue**: The player rounds the corner of the long hallway
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> AtEntrance
+
+  AtEntrance --> AttemptingToLeave: leave right
+  AtEntrance --> [*]: leave left
+
+  AttemptingToLeave --> AttemptingToLeave: default
+  AttemptingToLeave --> AtEntrance: continue
+```

--- a/docs/roomHandlers/roomception.md
+++ b/docs/roomHandlers/roomception.md
@@ -1,0 +1,27 @@
+# Roomception
+
+A room with a closed off room inside. The main room is basically a hallway that wraps around an innner room.
+The player can explore the main room (the hallway) or enter the inner room (which constitutes **leaving** the main room).
+
+## States
+
+- **AtEntrance**: The player is in a room with a room inside
+- **Exploring**: The player confirms that there is a room in this room and nothing else
+
+## Transitions
+
+- **leave**: The player leaves through the only available door
+- **explore**: The player wanders the hallway
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> AtEntrance
+
+  AtEntrance --> Exploring: explore
+  AtEntrance --> [*]: leave
+
+  Exploring --> AtEntrance: default
+  Exploring --> [*]: leave
+```


### PR DESCRIPTION
## Description

Added sequence diagrams for the major components of the app, and state diagrams for two proposed rooms.

I recommend starting with the changes to the README.md file. I'm using [mermaid](https://mermaid-js.github.io/mermaid/#/) code embedded in markdown files for the diagrams. GitHub will not be able to render the diagrams, and I couldn't find a working chrome extension, so I recommend pulling the branch and using the vscode extensions listed in the README to preview the diagrams.

I included two room proposals as an example of how we can use the docs to design rooms. It also provides context for the RoomHandler and RoomHandlerUtil docs. Once the structure of the docs makes sense, we can move the proposals to their own PR for discussion.