### PR TITLE
Skip typecheck when running tsnode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ jobs:
       - name: Lint Yaml
         if: always()
         run: npm run lint:yaml
+      - name: Typecheck
+        if: always()
+        run: npm run typecheck
       - name: Test
         if: always()
         run: npm test

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm install
 
 npm run compile:gameStateSchema
 
-npm run dev
+npm run --silent dev
 ```
 
 ### Configuring Vscode Formatting

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:yaml": "yamllint --ignore=node_modules/**/*.yaml **/*.yaml",
     "prepack": "npm run clean && tsc -b",
     "test": "nyc --extension .ts mocha \"tests/**/*.test.ts\"",
+    "typecheck": "tsc --noEmit -P tests/tsconfig.json ",
     "update-readme": "oclif-dev readme"
   },
   "bin": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "ts-node": {
+    "transpileOnly": true
+  },
   "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "declaration": true,


### PR DESCRIPTION
## Description

We use tsnode to develop and test our app. It allows us to run typescript code directly. To run typescript code you really only need to transpile it; the typecheck is optional. Since we have the typechecker running in the editor, we don't need to typecheck when we run the code.

Sometimes the editor doesn't show a typescript error until you interact with the file, so you might run into some seemingly opaque errors while developing.

I also added a typecheck to the CI. We were relying on the typecheck done by the test step in the CI.

## Background

I was working on implementing room handlers, and I was running `npm run dev` frequently to hand test the app. Each run took about 3 seconds.

## Data

Here are the median times over 3 runs of each command. I noticed that using `npm run dev` was slower than using the command that it references. I like having `npm run dev` in the docs since it's easier to reference and discover, but it's nice to know that it's technically slower.

The "Expected Prod" command looks like the "Dev" command but I disabled an internal `dev` flag in `./bin/run` so that it would reference the pre-transpiled js files. We would deploy these js files. 

### Dev (With npm run )

**Before**
![devBefore](https://user-images.githubusercontent.com/3934393/151643709-59dd88ed-dcd1-435e-930b-0c1899dcd3c1.png)

**After**
![devAfter](https://user-images.githubusercontent.com/3934393/151643729-7aa39b63-9efa-4ade-a034-5b957f033891.png)

### Dev (Without npm run )

**Before**
![dev2Before](https://user-images.githubusercontent.com/3934393/151644111-342c42a6-a8bb-4e99-9e24-1732f5b1790c.png)

**After**
![dev2After](https://user-images.githubusercontent.com/3934393/151643983-7b357a05-e80f-42de-9462-4ae9c118557d.png)

### Test

I ran `time npm test`

**Before**
![testsBefore](https://user-images.githubusercontent.com/3934393/151643735-9fc2d3bd-003c-43fd-b795-bf6b029b24d4.png)

**After**
![testsAfter](https://user-images.githubusercontent.com/3934393/151643733-6f2edfa2-58a9-41b8-bb94-dbf75446f5cd.png)

## Expected Prod
![prod](https://user-images.githubusercontent.com/3934393/151644130-06bfee58-5622-41cd-9416-5a17d6387abc.png)

