### PR TITLE
Add and apply IntegrationTestSuiteRegistrant to semantic-mocha

### DIFF
--- a/semantic-mocha/README.md
+++ b/semantic-mocha/README.md
@@ -64,8 +64,19 @@ or to register a suite of tests for units within the export.
 
 ```ts
 type ExportSuite = {
+  testIntegration: IntegrationSuiteRegistrant;
   testUnit: UnitSuiteRegistrant;
   assert: AssertionRegistrant;
+  testScenario: ScenarioRegistrant;
+}
+```
+
+### IntegrationSuiteRegistrant
+
+Enables registering integration test scenarios for a unit of an export of a module.
+
+```ts
+type ExportSuite = {
   testScenario: ScenarioRegistrant;
 }
 ```

--- a/semantic-mocha/README.md
+++ b/semantic-mocha/README.md
@@ -24,6 +24,8 @@ Start with importing one of the following:
 export const testModule: ModuleSuiteRegistrant;
 
 export const testSingletonModule: SingletonModuleSuiteRegistrant;
+
+export const testIntegration: IntegrationSuiteRegistrant;
 ```
 
 ### ModuleSuiteRegistrant

--- a/semantic-mocha/README.md
+++ b/semantic-mocha/README.md
@@ -16,7 +16,15 @@ The library is a work in progress and will need to be modified as new use cases 
 
 ## Current API
 
-Start with importing `testModule` or `testSingletonModule`.
+### Semantic-Mocha
+
+Start with importing one of the following:
+
+```ts
+export const testModule: ModuleSuiteRegistrant;
+
+export const testSingletonModule: SingletonModuleSuiteRegistrant;
+```
 
 ### ModuleSuiteRegistrant
 
@@ -26,7 +34,6 @@ Registers a suite of tests for a module. Takes a callback to register suites for
 type ModuleSuiteRegistrant =
   (description: string, (suite: ModuleSuite) => void) => void;
 
-export const testModule: ModuleSuiteRegistrant;
 ```
 
 ### SingletonModuleSuiteRegistrant
@@ -38,8 +45,6 @@ or to register a suite of tests for units within the export.
 ```ts
 type SingletonModuleSuiteRegistrant =
   (description: string, (suite: ExportSuite) => void) => void;
-
-export const testSingletonModule: SingletonModuleSuiteRegistrant;
 ```
 
 ### ModuleSuite

--- a/semantic-mocha/src/index.ts
+++ b/semantic-mocha/src/index.ts
@@ -84,6 +84,23 @@ type ScenarioAssertBuilder<TArranged, TResult> = {
   assert: MochafiedRegistrant<ChainableAssertionRegistrant<TArranged, TResult>>;
 };
 
+// Suites
+type ExportParentSuite = {
+  testExport: MochafiedRegistrant<ExportSuiteRegistrant>;
+};
+
+type UnitParentSuite = {
+  testUnit: MochafiedRegistrant<UnitSuiteRegistrant>;
+};
+
+type AssertableSuite = {
+  assert: MochafiedRegistrant<AssertionRegistrant>;
+};
+
+type ScenarioableSuite = {
+  testScenario: MochafiedRegistrant<ScenarioRegistrant>;
+};
+
 // UnitSuiteRegistrant
 type UnitSuiteRegistrant = (
   unitDescription: string,
@@ -92,10 +109,7 @@ type UnitSuiteRegistrant = (
 
 type UnitSuiteRegistrantCallback = (unitSuite: UnitSuite) => void;
 
-type UnitSuite = {
-  testScenario: MochafiedRegistrant<ScenarioRegistrant>;
-  assert: MochafiedRegistrant<AssertionRegistrant>;
-};
+type UnitSuite = AssertableSuite & ScenarioableSuite;
 
 // ExportSuiteRegistrant
 type ExportSuiteRegistrant = (
@@ -105,9 +119,7 @@ type ExportSuiteRegistrant = (
 
 type ExportSuiteRegistrantCallback = (exportSuite: ExportSuite) => void;
 
-type ExportSuite = {
-  testUnit: MochafiedRegistrant<UnitSuiteRegistrant>;
-} & UnitSuite;
+type ExportSuite = UnitParentSuite & AssertableSuite & ScenarioableSuite;
 
 // ModuleSuiteRegistrant
 type ModuleSuiteRegistrant = (
@@ -117,9 +129,7 @@ type ModuleSuiteRegistrant = (
 
 type ModuleSuiteRegistrantCallback = (moduleSuite: ModuleSuite) => void;
 
-type ModuleSuite = {
-  testExport: MochafiedRegistrant<ExportSuiteRegistrant>;
-};
+type ModuleSuite = ExportParentSuite;
 
 // SingletonModuleSuiteRegistrant
 type SingletonModuleSuiteRegistrant = (

--- a/semantic-mocha/src/index.ts
+++ b/semantic-mocha/src/index.ts
@@ -407,18 +407,25 @@ const buildRegisterUnitSuite = (
   );
 
 const buildRegisterIntegrationSuite = (
-  parentConfig: SuiteConfig,
+  parentConfig: SuiteConfig | null,
 ): MochafiedRegistrant<IntegrationSuiteRegistrant> =>
   mochafyRegistrant(
     mochaDescribe,
     (mochaFunction) => (integrationDescription, onIntegrationSuite) => {
       const config = new SuiteConfig(mochaFunction, integrationDescription);
-      parentConfig.add(config);
+
+      if (parentConfig) {
+        parentConfig.add(config);
+      }
 
       const integrationSuite: IntegrationSuite = {
         testScenario: buildRegisterScenario(config),
       };
       onIntegrationSuite(integrationSuite);
+
+      if (!parentConfig) {
+        config.apply();
+      }
     },
   );
 
@@ -465,5 +472,9 @@ const registerSingletonModuleSuite: MochafiedRegistrant<SingletonModuleSuiteRegi
     },
   );
 
+const registerIntegrationSuite: MochafiedRegistrant<IntegrationSuiteRegistrant> =
+  buildRegisterIntegrationSuite(null);
+
 export const testModule = registerModuleSuite;
 export const testSingletonModule = registerSingletonModuleSuite;
+export const testIntegration = registerIntegrationSuite;

--- a/tests/e2e/klickerKnight.test.ts
+++ b/tests/e2e/klickerKnight.test.ts
@@ -1,16 +1,15 @@
 import { expect } from 'chai';
 import { execSync } from 'child_process';
 import { databaseUtil } from '../../src/utils/databaseUtil';
+import { testIntegration } from '../testHelpers/semanticMocha';
 
-describe('klicker-knight', () => {
-  after(() => {
-    databaseUtil.delete();
-  });
-
-  it('trips on a flagstone', () => {
-    const result = execSync('npm run --silent klicker-knight');
-    expect(result.toString()).to.contain(
-      'flagstone. You fall and break your neck.',
-    );
-  });
+testIntegration('klicker-knight', ({ testScenario }) => {
+  testScenario('always')
+    .annihilate(() => {
+      databaseUtil.delete();
+    })
+    .act(() => execSync('npm run --silent klicker-knight').toString())
+    .assert('trips on a flagstone', (arrranged, result) => {
+      expect(result).to.contain('flagstone. You fall and break your neck.');
+    });
 });

--- a/tests/src/utils/databaseUtil.test.ts
+++ b/tests/src/utils/databaseUtil.test.ts
@@ -3,8 +3,8 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { defaultFilePath, databaseUtil } from '../../../src/utils/databaseUtil';
 import { testSingletonModule } from '../../testHelpers/semanticMocha';
 
-testSingletonModule('utils/databaseUtil', ({ testUnit }) => {
-  testUnit('hasGameFile', ({ testScenario }) => {
+testSingletonModule('utils/databaseUtil', ({ testIntegration }) => {
+  testIntegration('hasGameFile', ({ testScenario }) => {
     testScenario('when the file exists')
       .arrange(() => {
         writeFileSync(defaultFilePath, '');
@@ -27,7 +27,7 @@ testSingletonModule('utils/databaseUtil', ({ testUnit }) => {
       });
   });
 
-  testUnit('load', ({ testScenario }) => {
+  testIntegration('load', ({ testScenario }) => {
     testScenario('when the file exists and has data')
       .arrange(() => {
         writeFileSync(defaultFilePath, '{"foo":"bar"}');
@@ -62,7 +62,7 @@ testSingletonModule('utils/databaseUtil', ({ testUnit }) => {
       });
   });
 
-  testUnit('save', ({ testScenario }) => {
+  testIntegration('save', ({ testScenario }) => {
     testScenario('when the file exists and the new data is valid')
       .arrange(() => {
         writeFileSync(defaultFilePath, '');
@@ -130,7 +130,7 @@ testSingletonModule('utils/databaseUtil', ({ testUnit }) => {
       });
   });
 
-  testUnit('delete', ({ testScenario }) => {
+  testIntegration('delete', ({ testScenario }) => {
     testScenario('when the file exists')
       .arrange(() => {
         writeFileSync(defaultFilePath, '');

--- a/tests/testHelpers/semanticMocha.ts
+++ b/tests/testHelpers/semanticMocha.ts
@@ -1,1 +1,5 @@
-export { testModule, testSingletonModule } from '../../semantic-mocha/src';
+export {
+  testModule,
+  testSingletonModule,
+  testIntegration,
+} from '../../semantic-mocha/src';


### PR DESCRIPTION
- Adds `testIntegration` to the top level of semantic-mocha and to the ExportSuite object.
- Applied `exportSuite.testintegration` to `databaseUtil.test.ts`
- Applied top level `testIntegration` to the e2e test