### PR TITLE
Add colors to the CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "compile:gameStateSchema": "json2ts src/utils/types/gameState.schema.json > src/utils/types/gameState.d.ts",
     "klicker-knight": "ts-node src/klickerKnight",
     "lint:md": "markdownlint **/*.md --ignore node_modules",
-    "lint:ts": "eslint --ext .ts,.js .",
+    "lint:ts": "eslint --color --ext .ts,.js .",
     "lint:yaml": "yamllint --ignore=node_modules/**/*.yaml **/*.yaml",
     "test:custom-eslint-rules": "mocha -c --config eslint-local-rules/tests/.mocharc.js \"eslint-local-rules/tests/rules/**/*.test.ts\"",
     "test:e2e": "mocha -c \"tests/e2e/**/*.test.ts\"",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "klicker-knight": "ts-node src/klickerKnight",
     "lint:md": "markdownlint **/*.md --ignore node_modules",
     "lint:ts": "eslint --ext .ts,.js .",
-    "lint:yaml": "yamllint --format github --ignore=node_modules/**/*.yaml **/*.yaml",
+    "lint:yaml": "yamllint --ignore=node_modules/**/*.yaml **/*.yaml",
     "test:custom-eslint-rules": "mocha -c --config eslint-local-rules/tests/.mocharc.js \"eslint-local-rules/tests/rules/**/*.test.ts\"",
     "test:e2e": "mocha -c \"tests/e2e/**/*.test.ts\"",
     "test:semantic-mocha": "nyc --extension .ts mocha -c --config semantic-mocha/tests/.mocharc.js \"semantic-mocha/tests/**/*.test.ts\"",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "klicker-knight": "ts-node src/klickerKnight",
     "lint:md": "markdownlint **/*.md --ignore node_modules",
     "lint:ts": "eslint --ext .ts,.js .",
-    "lint:yaml": "yamllint --ignore=node_modules/**/*.yaml **/*.yaml",
+    "lint:yaml": "yamllint --ignore=node_modules/**/*.yaml **/*.yaml --format colored",
     "test:custom-eslint-rules": "mocha -c --config eslint-local-rules/tests/.mocharc.js \"eslint-local-rules/tests/rules/**/*.test.ts\"",
     "test:e2e": "mocha -c \"tests/e2e/**/*.test.ts\"",
     "test:semantic-mocha": "nyc --extension .ts mocha -c --config semantic-mocha/tests/.mocharc.js \"semantic-mocha/tests/**/*.test.ts\"",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "klicker-knight": "ts-node src/klickerKnight",
     "lint:md": "markdownlint **/*.md --ignore node_modules",
     "lint:ts": "eslint --ext .ts,.js .",
-    "lint:yaml": "yamllint --ignore=node_modules/**/*.yaml **/*.yaml --format github",
+    "lint:yaml": "yamllint --format github --ignore=node_modules/**/*.yaml **/*.yaml",
     "test:custom-eslint-rules": "mocha -c --config eslint-local-rules/tests/.mocharc.js \"eslint-local-rules/tests/rules/**/*.test.ts\"",
     "test:e2e": "mocha -c \"tests/e2e/**/*.test.ts\"",
     "test:semantic-mocha": "nyc --extension .ts mocha -c --config semantic-mocha/tests/.mocharc.js \"semantic-mocha/tests/**/*.test.ts\"",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "lint:md": "markdownlint **/*.md --ignore node_modules",
     "lint:ts": "eslint --ext .ts,.js .",
     "lint:yaml": "yamllint --ignore=node_modules/**/*.yaml **/*.yaml",
-    "test:custom-eslint-rules": "mocha --config eslint-local-rules/tests/.mocharc.js \"eslint-local-rules/tests/rules/**/*.test.ts\"",
-    "test:e2e": "mocha \"tests/e2e/**/*.test.ts\"",
-    "test:semantic-mocha": "nyc --extension .ts mocha --config semantic-mocha/tests/.mocharc.js \"semantic-mocha/tests/**/*.test.ts\"",
-    "test:src": "nyc --extension .ts mocha \"tests/src/**/*.test.ts\"",
+    "test:custom-eslint-rules": "mocha -c --config eslint-local-rules/tests/.mocharc.js \"eslint-local-rules/tests/rules/**/*.test.ts\"",
+    "test:e2e": "mocha -c \"tests/e2e/**/*.test.ts\"",
+    "test:semantic-mocha": "nyc --extension .ts mocha -c --config semantic-mocha/tests/.mocharc.js \"semantic-mocha/tests/**/*.test.ts\"",
+    "test:src": "nyc --extension .ts mocha -c \"tests/src/**/*.test.ts\"",
     "typecheck": "tsc --noEmit -P tests/tsconfig.json "
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "klicker-knight": "ts-node src/klickerKnight",
     "lint:md": "markdownlint **/*.md --ignore node_modules",
     "lint:ts": "eslint --ext .ts,.js .",
-    "lint:yaml": "yamllint --ignore=node_modules/**/*.yaml **/*.yaml --format colored",
+    "lint:yaml": "yamllint --ignore=node_modules/**/*.yaml **/*.yaml --format github",
     "test:custom-eslint-rules": "mocha -c --config eslint-local-rules/tests/.mocharc.js \"eslint-local-rules/tests/rules/**/*.test.ts\"",
     "test:e2e": "mocha -c \"tests/e2e/**/*.test.ts\"",
     "test:semantic-mocha": "nyc --extension .ts mocha -c --config semantic-mocha/tests/.mocharc.js \"semantic-mocha/tests/**/*.test.ts\"",

--- a/tests/src/utils/gameStateUtil.test.ts
+++ b/tests/src/utils/gameStateUtil.test.ts
@@ -88,7 +88,7 @@ testSingletonModule('utils/gameStateUtil', ({ testUnit }) => {
         sinon.restore();
       })
       .act((mockGameState) => gameStateUtil.save(mockGameState))
-      .assert('saves the game state', (mockGameState) => {
+      .assert('saves the game state', () => {
         expect((databaseUtil.save as SinonSpy).args).to.eql([
           [
             {


### PR DESCRIPTION
- `yamllint` step won't format even with the github flag -> https://yamllint.readthedocs.io/en/stable/integration.html?highlight=format#integration-with-github-actions
- `markdownlint` does not have a format/color flag as far as I can tell