### PR TITLE
Started adding a second room to highlight and fix issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ so it's difficult to determine where types should live such that there are no ci
 1. Compile the game state schemas with `npm run compile:gameStateSchema`
 1. Create a new subclass of [RoomHandler](./src/roomHandlers/roomHandler.ts)
     1. Create a type alias to reference the room type within the sublcass (for easier maintenance)
-1. Update the "allRoomHandlersByRoomType" in [roomUtil](./src/utils//roomUtil.ts) to include the new room handler
+1. Update the "allRoomHandlersByRoomType" in [roomUtil](./src/utils/roomUtil.ts) to include the new room handler

--- a/README.md
+++ b/README.md
@@ -49,3 +49,15 @@ Tests use [semantic-mocha](./semantic-mocha/README.md) which is currently being 
 
 As of 2022-02-02 we haven't solidified the architecture of the game,
 so it's difficult to determine where types should live such that there are no circular import dependencies
+
+### Adding a new Room State
+
+1. Add a doc for the room in [docs/rooms/](./docs/rooms/)
+    - Make sure it's consistent with the other docs.
+1. Update [gameState.schema.json](./src/utils/types/gameState.schema.json):
+    1. Add a new schema to the "definitions" object for your room state
+    1. Add a $ref to "definitions.RoomState" that points to the new schema
+1. Compile the game state schemas with `npm run compile:gameStateSchema`
+1. Create a new subclass of [RoomHandler](./src/roomHandlers/roomHandler.ts)
+    1. Create a type alias to reference the room type within the sublcass (for easier maintenance)
+1. Update the "allRoomHandlersByRoomType" in [roomUtil](./src/utils//roomUtil.ts) to include the new room handler

--- a/docs/rooms/exampleRoom2Room.md
+++ b/docs/rooms/exampleRoom2Room.md
@@ -15,9 +15,9 @@ This room will go away when other rooms are implemented.
 ## Commands
 
 - **leave**: You leave example room 2
-- **go2A**: You move to state 2A
-- **go2B**: You move to state 2B
-- **goStart**: You move back to the entrance
+- **goTo2A**: You move to state 2A
+- **goTo2B**: You move to state 2B
+- **goToEntrance**: You move back to the entrance
 
 ## Diagram
 
@@ -25,11 +25,11 @@ This room will go away when other rooms are implemented.
 stateDiagram-v2
   [*] --> AtEntrance
 
-  AtEntrance --> State2A: go2A
-  AtEntrance --> State2B: go2B
+  AtEntrance --> State2A: goTo2A
+  AtEntrance --> State2B: goTo2B
   AtEntrance --> [*]: leave
 
-  State2A --> AtEntrance: goStart
+  State2A --> AtEntrance: goToEntrance
 
-  State2B --> AtEntrance: goStart
+  State2B --> AtEntrance: goToEntrance
 ```

--- a/docs/rooms/exampleRoom3Room.md
+++ b/docs/rooms/exampleRoom3Room.md
@@ -18,10 +18,10 @@ This room will go away when other rooms are implemented.
 
 ## Commands
 
-- **leave**: You leave example room 3
-- **go3A**: You move to state 3A
-- **go3B**: You move to state 3B
-- **goStart**: You move back to the entrance
+- **leave**: You leave example room 3 having completed n laps
+- **goTo3A**: You move to state 3A
+- **goTo3B**: You move to state 3B
+- **goToEntrance**: You move back to the entrance
 
 ## Diagram
 
@@ -29,10 +29,10 @@ This room will go away when other rooms are implemented.
 stateDiagram-v2
   [*] --> AtEntrance
 
-  AtEntrance --> State3A: go2A
+  AtEntrance --> State3A: goTo3A
 
-  State3A --> State3B: go2B
+  State3A --> State3B: goTo3B
 
-  State3B --> AtEntrance: goStart
+  State3B --> AtEntrance: goToEntrance
   State3B --> [*]: leave
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@randograms/schema-to-generator": "^0.5.0",
+        "@randograms/schema-to-generator": "^0.5.1",
         "@tsconfig/node16": "^1.0.2",
         "@types/chai": "^4.2.22",
         "@types/eslint": "^8.4.1",
@@ -719,17 +719,44 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@randograms/schema-to-generator": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@randograms/schema-to-generator/-/schema-to-generator-0.5.0.tgz",
-      "integrity": "sha512-xKOhpXkk+7SChgNf0Dds8bGkqFyeoHre/rQEBo3t4mITBx4nuKboeuNzNWrDV0bs1IalrOLdP5iXmE5ldtG3vg==",
+    "node_modules/@randograms/schema-to-data": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@randograms/schema-to-data/-/schema-to-data-0.1.2.tgz",
+      "integrity": "sha512-g/0hP97haAIYBDOgtH6e7WamhmqPIGyDedOwxsHAsIBbN9VGFMiFubxUu/q5SRZWvwDcYwhPW6d5tagJf0xy7A==",
       "dev": true,
       "dependencies": {
+        "faker": "4.1.0",
+        "lodash": "4.17.19",
+        "randexp": "0.5.3",
+        "uuid": "8.3.0"
+      }
+    },
+    "node_modules/@randograms/schema-to-data/node_modules/lodash": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
+    },
+    "node_modules/@randograms/schema-to-data/node_modules/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@randograms/schema-to-generator": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@randograms/schema-to-generator/-/schema-to-generator-0.5.1.tgz",
+      "integrity": "sha512-DbkxoCjw+iog0JGchl3p8ZqMcXjlFNCwS4xV8RZGabXn59aHxNil+mcIfD/KwtJebCpfzOtX2DhCjS9ZIOsbkQ==",
+      "dev": true,
+      "dependencies": {
+        "@randograms/schema-to-data": "0.1.2",
         "ajv": "6.12.0",
         "ansi-colors": "4.1.1",
         "deep-freeze": "0.0.1",
-        "json-schema-faker": "0.5.0-rcv.24",
-        "lodash": "4.17.15"
+        "lodash": "4.17.19"
       }
     },
     "node_modules/@randograms/schema-to-generator/node_modules/ajv": {
@@ -745,9 +772,9 @@
       }
     },
     "node_modules/@randograms/schema-to-generator/node_modules/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -2422,6 +2449,12 @@
       "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
       "dev": true
     },
+    "node_modules/faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2564,12 +2597,6 @@
       "engines": {
         "node": ">=8.0.0"
       }
-    },
-    "node_modules/format-util": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==",
-      "dev": true
     },
     "node_modules/fromentries": {
       "version": "1.3.2",
@@ -3408,31 +3435,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-schema-faker": {
-      "version": "0.5.0-rcv.24",
-      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.24.tgz",
-      "integrity": "sha512-qwuRwv7dnUdqdwuifb6kJAVUKm0mzi4h/mzvMwDKxyWUzjxFCdVH/g9IfKxvc4M7rvAavr8pcx9uO1PNIIWE0g==",
-      "dev": true,
-      "dependencies": {
-        "json-schema-ref-parser": "^6.1.0",
-        "jsonpath-plus": "^2.0.0",
-        "randexp": "^0.5.3"
-      },
-      "bin": {
-        "jsf": "bin/gen.js"
-      }
-    },
-    "node_modules/json-schema-faker/node_modules/json-schema-ref-parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-      "dev": true,
-      "dependencies": {
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.12.1",
-        "ono": "^4.0.11"
-      }
-    },
     "node_modules/json-schema-ref-parser": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
@@ -3511,15 +3513,6 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
       "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
       "dev": true
-    },
-    "node_modules/jsonpath-plus": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-2.0.0.tgz",
-      "integrity": "sha512-ksXaz9+3SIZ5BMxgr7MQueYcR515VRZPuoDhIymUd1JcF6BnVaYJS7k4NJni4EHhvJaOIGGiPqT8+ifsGp6mBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0"
-      }
     },
     "node_modules/just-extend": {
       "version": "4.2.1",
@@ -4514,15 +4507,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/ono": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "dev": true,
-      "dependencies": {
-        "format-util": "^1.0.3"
       }
     },
     "node_modules/optionator": {
@@ -6237,17 +6221,43 @@
         "fastq": "^1.6.0"
       }
     },
-    "@randograms/schema-to-generator": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@randograms/schema-to-generator/-/schema-to-generator-0.5.0.tgz",
-      "integrity": "sha512-xKOhpXkk+7SChgNf0Dds8bGkqFyeoHre/rQEBo3t4mITBx4nuKboeuNzNWrDV0bs1IalrOLdP5iXmE5ldtG3vg==",
+    "@randograms/schema-to-data": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@randograms/schema-to-data/-/schema-to-data-0.1.2.tgz",
+      "integrity": "sha512-g/0hP97haAIYBDOgtH6e7WamhmqPIGyDedOwxsHAsIBbN9VGFMiFubxUu/q5SRZWvwDcYwhPW6d5tagJf0xy7A==",
       "dev": true,
       "requires": {
+        "faker": "4.1.0",
+        "lodash": "4.17.19",
+        "randexp": "0.5.3",
+        "uuid": "8.3.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+          "dev": true
+        }
+      }
+    },
+    "@randograms/schema-to-generator": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@randograms/schema-to-generator/-/schema-to-generator-0.5.1.tgz",
+      "integrity": "sha512-DbkxoCjw+iog0JGchl3p8ZqMcXjlFNCwS4xV8RZGabXn59aHxNil+mcIfD/KwtJebCpfzOtX2DhCjS9ZIOsbkQ==",
+      "dev": true,
+      "requires": {
+        "@randograms/schema-to-data": "0.1.2",
         "ajv": "6.12.0",
         "ansi-colors": "4.1.1",
         "deep-freeze": "0.0.1",
-        "json-schema-faker": "0.5.0-rcv.24",
-        "lodash": "4.17.15"
+        "lodash": "4.17.19"
       },
       "dependencies": {
         "ajv": {
@@ -6263,9 +6273,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
           "dev": true
         }
       }
@@ -7519,6 +7529,12 @@
         }
       }
     },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7628,12 +7644,6 @@
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
       }
-    },
-    "format-util": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
-      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==",
-      "dev": true
     },
     "fromentries": {
       "version": "1.3.2",
@@ -8188,30 +8198,6 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "json-schema-faker": {
-      "version": "0.5.0-rcv.24",
-      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.24.tgz",
-      "integrity": "sha512-qwuRwv7dnUdqdwuifb6kJAVUKm0mzi4h/mzvMwDKxyWUzjxFCdVH/g9IfKxvc4M7rvAavr8pcx9uO1PNIIWE0g==",
-      "dev": true,
-      "requires": {
-        "json-schema-ref-parser": "^6.1.0",
-        "jsonpath-plus": "^2.0.0",
-        "randexp": "^0.5.3"
-      },
-      "dependencies": {
-        "json-schema-ref-parser": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-          "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-          "dev": true,
-          "requires": {
-            "call-me-maybe": "^1.0.1",
-            "js-yaml": "^3.12.1",
-            "ono": "^4.0.11"
-          }
-        }
-      }
-    },
     "json-schema-ref-parser": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
@@ -8273,12 +8259,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
       "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
-      "dev": true
-    },
-    "jsonpath-plus": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-2.0.0.tgz",
-      "integrity": "sha512-ksXaz9+3SIZ5BMxgr7MQueYcR515VRZPuoDhIymUd1JcF6BnVaYJS7k4NJni4EHhvJaOIGGiPqT8+ifsGp6mBw==",
       "dev": true
     },
     "just-extend": {
@@ -9074,15 +9054,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "ono": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "dev": true,
-      "requires": {
-        "format-util": "^1.0.3"
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@randograms/schema-to-generator": "^0.5.0",
+    "@randograms/schema-to-generator": "^0.5.1",
     "@tsconfig/node16": "^1.0.2",
     "@types/chai": "^4.2.22",
     "@types/eslint": "^8.4.1",

--- a/src/roomHandlers/exampleRoom2Handler.ts
+++ b/src/roomHandlers/exampleRoom2Handler.ts
@@ -1,31 +1,33 @@
+import { RoomHandler } from './roomHandler';
+
 import {
-  NarrowedRoomState,
   Command,
-  CommandHandler,
+  NarrowedRoomState,
   NullableCommandHandler,
   StateDescriptionAccessor,
 } from '../utils/types';
-import { RoomHandler } from './roomHandler';
 
-const roomType = 'exampleRoom1';
+const roomType = 'exampleRoom2';
 type TRoomType = typeof roomType;
 type TRoomState = NarrowedRoomState<TRoomType>;
-type TCommandHandler = CommandHandler<TRoomType>;
 type TNullableCommandHandler = NullableCommandHandler<TRoomType>;
-
-const leaveHandler: TCommandHandler = () => ({
-  commandDescription: 'You leave example room 1',
-  roomState: null,
-});
 
 const stateDescriptionAccessor: StateDescriptionAccessor<TRoomState> = {
   AtEntrance: {
-    playerStateDescription: 'You are in example room 1',
-    availableCommands: ['leave'],
+    playerStateDescription: 'You are in example room 2',
+    availableCommands: ['leave', 'goTo2A', 'goTo2B'],
+  },
+  State2A: {
+    playerStateDescription: 'You are in state 2A',
+    availableCommands: ['goToEntrance'],
+  },
+  State2B: {
+    playerStateDescription: 'You are in state 2B',
+    availableCommands: ['goToEntrance'],
   },
 };
 
-export class ExampleRoom1Handler extends RoomHandler<TRoomType> {
+export class ExampleRoom2Handler extends RoomHandler<TRoomType> {
   constructor() {
     super(stateDescriptionAccessor);
   }
@@ -42,7 +44,10 @@ export class ExampleRoom1Handler extends RoomHandler<TRoomType> {
     command: Command,
   ): TNullableCommandHandler {
     if (command === 'leave') {
-      return leaveHandler;
+      return () => ({
+        commandDescription: 'You leave example room 2',
+        roomState: null,
+      });
     }
 
     return null;

--- a/src/utils/roomUtil.ts
+++ b/src/utils/roomUtil.ts
@@ -1,5 +1,5 @@
 import { ExampleRoom1Handler } from '../roomHandlers/exampleRoom1Handler';
-import { RoomHandler } from '../roomHandlers/roomHandler';
+import { ExampleRoom2Handler } from '../roomHandlers/exampleRoom2Handler';
 import { DeveloperError } from './developerError';
 import {
   ROOM_TYPES_TUPLE,
@@ -11,6 +11,7 @@ import {
 
 const allRoomHandlersByRoomType: AllRoomHandlersByRoomType = {
   exampleRoom1: new ExampleRoom1Handler(),
+  exampleRoom2: new ExampleRoom2Handler(),
 };
 
 export const roomUtil = {
@@ -25,7 +26,7 @@ export const roomUtil = {
     return roomHandler.createRoomState();
   },
 
-  getRandomRoomHandler: (): RoomHandler<RoomType> => {
+  getRandomRoomHandler: (): AllRoomHandlersByRoomType[RoomType] => {
     const randomIndex = Math.floor(Math.random() * ROOM_TYPES_TUPLE.length);
     const randomRoomType = ROOM_TYPES_TUPLE[randomIndex];
 
@@ -42,7 +43,10 @@ export const roomUtil = {
     return roomUtil.getRandomRoomHandler().createRoomState();
   },
 
-  getRoomHandlerByRoomType: (roomType: RoomType): RoomHandler<RoomType> => {
-    return allRoomHandlersByRoomType[roomType];
+  getRoomHandlerByRoomType: <TRoomType extends RoomType>(
+    roomType: TRoomType,
+  ): AllRoomHandlersByRoomType[TRoomType] => {
+    const roomHandler = allRoomHandlersByRoomType[roomType];
+    return roomHandler;
   },
 };

--- a/src/utils/types/gameState.d.ts
+++ b/src/utils/types/gameState.d.ts
@@ -5,7 +5,7 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type RoomState = ExampleRoom1;
+export type RoomState = ExampleRoom1 | ExampleRoom2;
 
 export interface GameState {
   roomState: RoomState;
@@ -13,4 +13,8 @@ export interface GameState {
 export interface ExampleRoom1 {
   type: 'exampleRoom1';
   playerState: 'AtEntrance';
+}
+export interface ExampleRoom2 {
+  type: 'exampleRoom2';
+  playerState: 'AtEntrance' | 'State2A' | 'State2B';
 }

--- a/src/utils/types/gameState.schema.json
+++ b/src/utils/types/gameState.schema.json
@@ -16,9 +16,28 @@
       "required": ["type", "playerState"],
       "additionalProperties": false
     },
+    "ExampleRoom2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "exampleRoom2"
+        },
+        "playerState": {
+          "enum": [
+            "AtEntrance",
+            "State2A",
+            "State2B"
+          ]
+        }
+      },
+      "required": ["type", "playerState"],
+      "additionalProperties": false
+    },
     "RoomState": {
+      "type": "object",
       "oneOf": [
-        { "$ref": "#/definitions/ExampleRoom1" }
+        { "$ref": "#/definitions/ExampleRoom1" },
+        { "$ref": "#/definitions/ExampleRoom2" }
       ]
     }
   },

--- a/src/utils/types/gameStateSchema.ts
+++ b/src/utils/types/gameStateSchema.ts
@@ -1,0 +1,49 @@
+import gameStateSchemaWithReferences from './gameState.schema.json';
+
+const { definitions } = gameStateSchemaWithReferences;
+type Definitions = typeof definitions;
+
+type DefinitionMap = {
+  [K in keyof Definitions as `#/definitions/${K}`]: Definitions[K];
+};
+const map = Object.fromEntries(
+  Object.entries(definitions).map(([schemaName, schema]) => [
+    `#/definitions/${schemaName}`,
+    schema,
+  ]),
+) as DefinitionMap;
+
+const dereference = (data: unknown): unknown => {
+  if (data === null || typeof data !== 'object') {
+    return data;
+  }
+
+  if (Array.isArray(data)) {
+    return data.map((innerData) => dereference(innerData)) as unknown;
+  }
+
+  if ('$ref' in data) {
+    const lookupValue = (data as { $ref: unknown }).$ref as keyof DefinitionMap;
+    if (!(lookupValue in map)) {
+      throw Error(`Bad reference ${lookupValue}`);
+    }
+
+    return dereference(map[lookupValue]);
+  }
+
+  return Object.fromEntries(
+    Object.entries(data).map(([key, value]) => {
+      if (key === '$ref' && typeof value === 'string') {
+        if (!(value in map)) {
+          throw Error(`Bad reference ${value}`);
+        }
+
+        return [key, map[value as keyof DefinitionMap]];
+      }
+
+      return [key, dereference(value)];
+    }),
+  );
+};
+
+export const gameStateSchema = dereference(gameStateSchemaWithReferences);

--- a/src/utils/types/roomTypesTuple.ts
+++ b/src/utils/types/roomTypesTuple.ts
@@ -1,4 +1,4 @@
 // THIS FILE WAS AUTOMATICALLY GENERATED
 // Use "npm run compile:gameStateSchema" to rebuild
 
-export const ROOM_TYPES_TUPLE = ['exampleRoom1'] as const;
+export const ROOM_TYPES_TUPLE = ['exampleRoom1', 'exampleRoom2'] as const;

--- a/tests/e2e/klickerKnight.test.ts
+++ b/tests/e2e/klickerKnight.test.ts
@@ -14,7 +14,7 @@ testIntegration('klicker-knight', ({ testScenario }) => {
     .annihilate(cleanupSave)
     .act(() => run(''))
     .assert('outputs a room description', (arranged, result) => {
-      expect(result).to.include('You are in example room 1');
+      expect(result).to.match(/You are in example room \d/);
     })
     .assert('outputs available commands', (arranged, result) => {
       expect(result).to.include('Available Commands: leave');
@@ -24,10 +24,10 @@ testIntegration('klicker-knight', ({ testScenario }) => {
     .annihilate(cleanupSave)
     .act(() => run('leave'))
     .assert('outputs a command description', (arranged, result) => {
-      expect(result).to.include('You leave example room 1');
+      expect(result).to.match(/You leave example room \d/);
     })
     .assert('outputs a room description', (arranged, result) => {
-      expect(result).to.include('You are in example room 1');
+      expect(result).to.match(/You are in example room \d/);
     })
     .assert('outputs available commands', (arranged, result) => {
       expect(result).to.include('Available Commands: leave');
@@ -40,7 +40,7 @@ testIntegration('klicker-knight', ({ testScenario }) => {
       expect(result).to.include('You cannot do that');
     })
     .assert('outputs a room description', (arranged, result) => {
-      expect(result).to.include('You are in example room 1');
+      expect(result).to.match(/You are in example room \d/);
     })
     .assert('outputs available commands', (arranged, result) => {
       expect(result).to.include('Available Commands: leave');
@@ -53,7 +53,7 @@ testIntegration('klicker-knight', ({ testScenario }) => {
       expect(result).to.include('You cannot do that');
     })
     .assert('outputs a room description', (arranged, result) => {
-      expect(result).to.include('You are in example room 1');
+      expect(result).to.match(/You are in example room \d/);
     })
     .assert('outputs available commands', (arranged, result) => {
       expect(result).to.include('Available Commands: leave');

--- a/tests/src/roomHandlers/exampleRoom1Handler.test.ts
+++ b/tests/src/roomHandlers/exampleRoom1Handler.test.ts
@@ -3,6 +3,10 @@ import { testSingletonModule } from '../../testHelpers/semanticMocha';
 import { ExampleRoom1Handler } from '../../../src/roomHandlers/exampleRoom1Handler';
 import { CommandResult, RoomState } from '../../../src/utils/types';
 
+const roomType = 'exampleRoom1';
+type TRoomType = typeof roomType;
+type TCommandResult = CommandResult<TRoomType>;
+
 testSingletonModule(
   'roomHandlers/ExampleRoom1Handler',
   ({ testIntegration }) => {
@@ -11,7 +15,7 @@ testSingletonModule(
         .arrange(() => {
           const roomHandler = new ExampleRoom1Handler();
           const inputRoomState: RoomState = {
-            type: 'exampleRoom1',
+            type: roomType,
             playerState: 'AtEntrance',
           };
           return { roomHandler, inputRoomState };
@@ -20,7 +24,7 @@ testSingletonModule(
           roomHandler.run(inputRoomState, 'leave'),
         )
         .assert('returns a leave result', (arranged, result) => {
-          const expectedResult: CommandResult<'exampleRoom1'> = {
+          const expectedResult: TCommandResult = {
             commandDescription: 'You leave example room 1',
             roomState: null,
           };

--- a/tests/src/roomHandlers/exampleRoom2Handler.test.ts
+++ b/tests/src/roomHandlers/exampleRoom2Handler.test.ts
@@ -1,0 +1,10 @@
+import { testSingletonModule } from '../../testHelpers/semanticMocha';
+
+testSingletonModule(
+  'roomHandlers/ExampleRoom2Handler',
+  ({ testIntegration }) => {
+    // TODO: Create a utility to make state transition tests from mermaid code
+    // TODO: fix and merge schema-to-generator issues
+    testIntegration.skip('run', () => {});
+  },
+);

--- a/tests/src/utils/roomUtil.test.ts
+++ b/tests/src/utils/roomUtil.test.ts
@@ -1,8 +1,10 @@
 import { expect } from 'chai';
+import sinon, { SinonSpy } from 'sinon';
 import { testSingletonModule } from '../../testHelpers/semanticMocha';
 import { roomUtil } from '../../../src/utils/roomUtil';
 import { generateRoomState } from '../../testHelpers/generateGameState';
 import { RoomState } from '../../../src/utils/types';
+import { ExampleRoom1Handler } from '../../../src/roomHandlers/exampleRoom1Handler';
 
 testSingletonModule('utils/roomUtil', ({ testUnit }) => {
   testUnit('coerceRoomState', ({ testScenario }) => {
@@ -17,7 +19,20 @@ testSingletonModule('utils/roomUtil', ({ testUnit }) => {
       });
 
     testScenario('when the room state is null')
+      .arrange(() => {
+        sinon
+          .stub(roomUtil, 'getRandomRoomHandler')
+          .returns(new ExampleRoom1Handler());
+      })
+      .annihilate(() => {
+        sinon.restore();
+      })
       .act(() => roomUtil.coerceRoomState(null))
+      .assert('fetches a random room handler', () => {
+        expect((roomUtil.getRandomRoomHandler as SinonSpy).calledOnce).to.eq(
+          true,
+        );
+      })
       .assert('returns a new room state', (arranged, result) => {
         const expectedResult: RoomState = {
           type: 'exampleRoom1',

--- a/tests/testHelpers/generateGameState.ts
+++ b/tests/testHelpers/generateGameState.ts
@@ -1,8 +1,10 @@
 import { schemaToGenerator } from '@randograms/schema-to-generator';
-import gameStateSchema from '../../src/utils/types/gameState.schema.json';
+import { gameStateSchema } from '../../src/utils/types/gameStateSchema';
 import { roomStateSchema } from '../../src/utils/types/roomStateSchema';
 import { GameState, RoomState } from '../../src/utils/types';
 
-export const generateGameState = schemaToGenerator<GameState>(gameStateSchema);
+export const generateGameState = schemaToGenerator<GameState>(
+  gameStateSchema as Record<string, unknown>,
+);
 
 export const generateRoomState = schemaToGenerator<RoomState>(roomStateSchema);


### PR DESCRIPTION
Atomic commits ftw

- Found and fixed tests that only assume there is one room
- Found a bug in schema-to-generator where it wouldn't restrict the possible "enum" values
    - Example: setting type to "exampleRoom1" would still allow PlayerState values "State2A" and "State2B"
    -  I forgot that the new version of schema-to-generator cannot parse refs, so I had to fix that as well
        - let me know if you can find an existing **synchronous** JSON-schema dereferencing library (I can only find async ones)