### PR TITLE
Derive narrowed room state from json-schema room state definitions

### DIFF
--- a/scripts/compileRoomTypesTuple.ts
+++ b/scripts/compileRoomTypesTuple.ts
@@ -1,17 +1,42 @@
 import fs from 'fs';
-import { roomStateSchema } from '../src/utils/types/roomStateSchema';
+import { roomStateDefinitionNameValueTuples } from '../src/utils/types/roomStateSchema';
 
-const roomTypes: string[] = roomStateSchema.oneOf.map(
-  (schema) => schema.properties.type.const,
+const schemaTypeScriptTypes = roomStateDefinitionNameValueTuples.map(
+  ([schemaName, schema]) => ({
+    roomStateTypeIdentifier: schemaName,
+    roomTypeType: `'${schema.properties.type.const}'`,
+  }),
+);
+
+const typeScriptTypeImportList = schemaTypeScriptTypes
+  .map(({ roomStateTypeIdentifier }) => roomStateTypeIdentifier)
+  .join(', ');
+
+const roomTypeTypes: string[] = schemaTypeScriptTypes.map(
+  ({ roomTypeType }) => roomTypeType,
 );
 
 const output = [
   '// THIS FILE WAS AUTOMATICALLY GENERATED',
   '// Use "npm run compile:gameStateSchema" to rebuild',
   '',
+  '// eslint-disable-next-line import/no-restricted-paths',
+  `import { ${typeScriptTypeImportList} } from './gameState';`,
+  '',
   'export const ROOM_TYPES_TUPLE = [',
-  ...roomTypes.map((roomType) => `  '${roomType}',`),
+  ...roomTypeTypes.map((roomTypeType) => `  ${roomTypeType},`),
   '] as const;',
+  '',
+  'export type RoomTypesTuple = typeof ROOM_TYPES_TUPLE;',
+  '',
+  'export type RoomType = RoomTypesTuple[number];',
+  '',
+  'export type NarrowedRoomState<TRoomType extends RoomType> =',
+  ...schemaTypeScriptTypes.map(
+    ({ roomStateTypeIdentifier, roomTypeType }) =>
+      `  TRoomType extends ${roomTypeType} ? ${roomStateTypeIdentifier} :`,
+  ),
+  '  never;',
 ].join('\n');
 
 fs.writeFileSync('src/utils/types/roomTypesTuple.ts', output);

--- a/src/roomHandlers/exampleRoom1Handler.ts
+++ b/src/roomHandlers/exampleRoom1Handler.ts
@@ -10,6 +10,7 @@ import { RoomHandler } from './roomHandler';
 const roomType = 'exampleRoom1';
 type TRoomType = typeof roomType;
 type TRoomState = NarrowedRoomState<TRoomType>;
+type TStateDescriptionAccessor = StateDescriptionAccessor<TRoomState>;
 type TCommandHandler = CommandHandler<TRoomType>;
 type TNullableCommandHandler = NullableCommandHandler<TRoomType>;
 
@@ -18,7 +19,7 @@ const leaveHandler: TCommandHandler = () => ({
   roomState: null,
 });
 
-const stateDescriptionAccessor: StateDescriptionAccessor<TRoomState> = {
+const stateDescriptionAccessor: TStateDescriptionAccessor = {
   AtEntrance: {
     playerStateDescription: 'You are in example room 1',
     availableCommands: ['leave'],

--- a/src/roomHandlers/exampleRoom2Handler.ts
+++ b/src/roomHandlers/exampleRoom2Handler.ts
@@ -10,9 +10,10 @@ import {
 const roomType = 'exampleRoom2';
 type TRoomType = typeof roomType;
 type TRoomState = NarrowedRoomState<TRoomType>;
+type TStateDescriptionAccessor = StateDescriptionAccessor<TRoomState>;
 type TNullableCommandHandler = NullableCommandHandler<TRoomType>;
 
-const stateDescriptionAccessor: StateDescriptionAccessor<TRoomState> = {
+const stateDescriptionAccessor: TStateDescriptionAccessor = {
   AtEntrance: {
     playerStateDescription: 'You are in example room 2',
     availableCommands: ['leave', 'goTo2A', 'goTo2B'],

--- a/src/roomHandlers/roomHandler.ts
+++ b/src/roomHandlers/roomHandler.ts
@@ -53,6 +53,8 @@ export abstract class RoomHandler<TRoomType extends RoomType> {
   getRoomStateDescription(
     roomState: NarrowedRoomState<TRoomType>,
   ): RoomStateDescription {
-    return this.stateDescriptionAccessor[roomState.playerState];
+    return this.stateDescriptionAccessor[
+      roomState.playerState as NarrowedRoomState<TRoomType>['playerState']
+    ];
   }
 }

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -1,21 +1,19 @@
 /* eslint-disable import/no-restricted-paths */
 import type { RoomState } from './gameState';
-import type { ROOM_TYPES_TUPLE } from './roomTypesTuple';
+import type { RoomType, NarrowedRoomState } from './roomTypesTuple';
 /* eslint-enable import/no-restricted-paths */
 
 import type { RoomHandler } from '../../roomHandlers/roomHandler';
 
 // Game State
-export type { GameState, RoomState, ExampleRoom1 } from './gameState'; // eslint-disable-line import/no-restricted-paths
+export type { GameState, RoomState } from './gameState'; // eslint-disable-line import/no-restricted-paths
 
-// eslint-disable-next-line import/no-restricted-paths
-export { ROOM_TYPES_TUPLE } from './roomTypesTuple';
-export type RoomTypesTuple = typeof ROOM_TYPES_TUPLE;
-export type RoomType = RoomTypesTuple[number];
-
-export type NarrowedRoomState<TRoomType extends RoomType> = RoomState & {
-  type: TRoomType;
-};
+export {
+  ROOM_TYPES_TUPLE,
+  RoomTypesTuple,
+  RoomType,
+  NarrowedRoomState,
+} from './roomTypesTuple'; // eslint-disable-line import/no-restricted-paths
 
 // Game I/O
 export type Command = DefaultCommand | string;

--- a/src/utils/types/roomStateSchema.ts
+++ b/src/utils/types/roomStateSchema.ts
@@ -1,14 +1,19 @@
 import { ValuesOf } from './index';
 import gameStateSchema from './gameState.schema.json';
 
-export type RoomStateSchema = ValuesOf<
-  // The "RoomState" schema is a list of the individual room state schemas, so it can be safely omitted
-  Omit<typeof gameStateSchema.definitions, 'RoomState'>
+// The "RoomState" schema is a list of the individual room state schemas, so it can be safely omitted
+type RoomStateDefinitions = Omit<
+  typeof gameStateSchema.definitions,
+  'RoomState'
 >;
+
+export type RoomStateSchema = ValuesOf<RoomStateDefinitions>;
+
+export const roomStateDefinitionNameValueTuples = Object.entries(
+  gameStateSchema.definitions,
+).filter(([key]) => key !== 'RoomState') as [string, RoomStateSchema][];
 
 export const roomStateSchema = {
   ...gameStateSchema.definitions.RoomState,
-  oneOf: Object.entries(gameStateSchema.definitions)
-    .filter(([key]) => key !== 'RoomState')
-    .map(([, schema]) => schema) as RoomStateSchema[],
+  oneOf: roomStateDefinitionNameValueTuples.map(([, schema]) => schema),
 };

--- a/src/utils/types/roomTypesTuple.ts
+++ b/src/utils/types/roomTypesTuple.ts
@@ -1,4 +1,18 @@
 // THIS FILE WAS AUTOMATICALLY GENERATED
 // Use "npm run compile:gameStateSchema" to rebuild
 
+// eslint-disable-next-line import/no-restricted-paths
+import { ExampleRoom1, ExampleRoom2 } from './gameState';
+
 export const ROOM_TYPES_TUPLE = ['exampleRoom1', 'exampleRoom2'] as const;
+
+export type RoomTypesTuple = typeof ROOM_TYPES_TUPLE;
+
+export type RoomType = RoomTypesTuple[number];
+
+export type NarrowedRoomState<TRoomType extends RoomType> =
+  TRoomType extends 'exampleRoom1'
+    ? ExampleRoom1
+    : TRoomType extends 'exampleRoom2'
+    ? ExampleRoom2
+    : never;


### PR DESCRIPTION
TypeScript isn't smart enough to understand the relationship between a type derived from `RoomType` and the type returned by  `NarrowedRoomState<RoomType>` for a specific `RoomType`. This new version fixes that.