### PR TITLE
Fix eslint-ignore placement in compiled file

### DIFF
--- a/scripts/compileRoomTypesTuple.ts
+++ b/scripts/compileRoomTypesTuple.ts
@@ -8,9 +8,9 @@ const schemaTypeScriptTypes = roomStateDefinitionNameValueTuples.map(
   }),
 );
 
-const typeScriptTypeImportList = schemaTypeScriptTypes
-  .map(({ roomStateTypeIdentifier }) => roomStateTypeIdentifier)
-  .join(', ');
+const typeScriptTypeImports = schemaTypeScriptTypes.map(
+  ({ roomStateTypeIdentifier }) => `  ${roomStateTypeIdentifier},`,
+);
 
 const roomTypeTypes: string[] = schemaTypeScriptTypes.map(
   ({ roomTypeType }) => roomTypeType,
@@ -20,8 +20,10 @@ const output = [
   '// THIS FILE WAS AUTOMATICALLY GENERATED',
   '// Use "npm run compile:gameStateSchema" to rebuild',
   '',
-  '// eslint-disable-next-line import/no-restricted-paths',
-  `import { ${typeScriptTypeImportList} } from './gameState';`,
+  'import {',
+  ...typeScriptTypeImports,
+  '  // eslint-disable-next-line import/no-restricted-paths',
+  "} from './gameState';",
   '',
   'export const ROOM_TYPES_TUPLE = [',
   ...roomTypeTypes.map((roomTypeType) => `  ${roomTypeType},`),

--- a/src/utils/types/roomTypesTuple.ts
+++ b/src/utils/types/roomTypesTuple.ts
@@ -1,8 +1,12 @@
 // THIS FILE WAS AUTOMATICALLY GENERATED
 // Use "npm run compile:gameStateSchema" to rebuild
 
-// eslint-disable-next-line import/no-restricted-paths
-import { ExampleRoom1, ExampleRoom2, ExampleRoom3 } from './gameState';
+import {
+  ExampleRoom1,
+  ExampleRoom2,
+  ExampleRoom3,
+  // eslint-disable-next-line import/no-restricted-paths
+} from './gameState';
 
 export const ROOM_TYPES_TUPLE = [
   'exampleRoom1',


### PR DESCRIPTION
With the previous version, when there were more than 3 room types, the eslint ignore comment was moved to the wrong place.